### PR TITLE
Add vertico-posframe for non-shifting minibuffer completion

### DIFF
--- a/lisp/init-completions.el
+++ b/lisp/init-completions.el
@@ -56,6 +56,17 @@
               ("M-DEL" . vertico-directory-delete-word))
   :hook (rfn-eshadow-update-overlay . vertico-directory-tidy))
 
+;; show vertico in a centered child frame instead of expanding the
+;; minibuffer, so windows don't shift when M-x etc. open
+(use-package vertico-posframe
+  :ensure t
+  :after vertico
+  :custom
+  (vertico-posframe-poshandler #'posframe-poshandler-frame-center)
+  (vertico-posframe-parameters '((left-fringe . 8) (right-fringe . 8)))
+  :config
+  (vertico-posframe-mode 1))
+
 (use-package marginalia
   :ensure t
   :config


### PR DESCRIPTION
Displays the vertico candidate list in a centered child frame instead of expanding the minibuffer, so windows no longer shift up when M-x (or any completing-read) opens.

- New use-package block in lisp/init-completions.el after vertico-directory
- Centered via posframe-poshandler-frame-center, with 8px fringes
- posframe itself is already installed (elpa/), only the small vertico-posframe wrapper is new
- GUI-only by nature; vertico-posframe falls back to normal minibuffer display in a terminal

No old vertico-posframe settings existed in config.org or the backup files to restore, so this is a fresh block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7gfjjamDPEWCejMYVCL5u