### PR TITLE
Remove vertico-posframe (broken on emacs-plus@31/Tahoe) and tidy completion config

### DIFF
--- a/lisp/init-completions.el
+++ b/lisp/init-completions.el
@@ -11,13 +11,15 @@
          ("M-g i"   . consult-imenu)))
 
 (use-package consult-project-extra
+  :ensure t
   :defer t
   :bind
   (("C-c p F" . consult-project-extra-find)
    ("C-c p o" . consult-project-extra-find-other-window)))
 
 (use-package consult-todo
-  :demand t)
+  :ensure t
+  :commands (consult-todo consult-todo-all consult-todo-project))
 
 (use-package embark
   :ensure t
@@ -27,7 +29,8 @@
          ("C-c C-e" . embark-export)))
 
 (use-package embark-consult
-  :ensure t)
+  :ensure t
+  :hook (embark-collect-mode . consult-preview-at-point-mode))
 
 (use-package vertico
   :ensure t
@@ -91,6 +94,7 @@
   (setq completion-styles '(orderless basic)))
 
 (use-package cape
+  :ensure t
   :defer t
   :bind (("C-c p p" . completion-at-point)
          ("C-c p d" . cape-dabbrev)
@@ -98,7 +102,6 @@
          ("C-c p f" . cape-file)
          ("C-c p k" . cape-keyword)
          ("C-c p a" . cape-abbrev)
-         ("C-c p i" . cape-ispell)
          ("C-c p l" . cape-line)
          ("C-c p w" . cape-dict)
          ("C-c p r" . cape-rfc1345))

--- a/lisp/init-completions.el
+++ b/lisp/init-completions.el
@@ -46,7 +46,7 @@
   (add-hook 'minibuffer-setup-hook #'vertico-repeat-save)
   (vertico-mouse-mode 1)
   (vertico-multiform-mode 1)
-  (setq vertico-count 20)
+  (setq vertico-count 12)
   (setq vertico-cycle t)
   (setq vertico-resize nil))
 

--- a/lisp/init-completions.el
+++ b/lisp/init-completions.el
@@ -59,17 +59,6 @@
               ("M-DEL" . vertico-directory-delete-word))
   :hook (rfn-eshadow-update-overlay . vertico-directory-tidy))
 
-;; show vertico in a centered child frame instead of expanding the
-;; minibuffer, so windows don't shift when M-x etc. open
-(use-package vertico-posframe
-  :ensure t
-  :after vertico
-  :custom
-  (vertico-posframe-poshandler #'posframe-poshandler-frame-center)
-  (vertico-posframe-parameters '((left-fringe . 8) (right-fringe . 8)))
-  :config
-  (vertico-posframe-mode 1))
-
 (use-package marginalia
   :ensure t
   :config

--- a/lisp/init-settings.el
+++ b/lisp/init-settings.el
@@ -72,6 +72,9 @@
 (global-set-key (kbd "C-c e") (lambda () (interactive) (find-file "~/.emacs.d/init.org")))
 (global-set-key (kbd "M-n") 'forward-paragraph)
 (global-set-key (kbd "M-p") 'backward-paragraph)
+;; non-native fullscreen: child frames (posframe) can't render over
+;; macOS native-fullscreen frames, which breaks vertico-posframe
+(setq ns-use-native-fullscreen nil)
 (bind-key "<s-return>" 'toggle-frame-fullscreen)
 (bind-key "s-[" 'previous-buffer)
 (bind-key "s-]" 'next-buffer)

--- a/lisp/init-settings.el
+++ b/lisp/init-settings.el
@@ -72,9 +72,6 @@
 (global-set-key (kbd "C-c e") (lambda () (interactive) (find-file "~/.emacs.d/init.org")))
 (global-set-key (kbd "M-n") 'forward-paragraph)
 (global-set-key (kbd "M-p") 'backward-paragraph)
-;; non-native fullscreen: child frames (posframe) can't render over
-;; macOS native-fullscreen frames, which breaks vertico-posframe
-(setq ns-use-native-fullscreen nil)
 (bind-key "<s-return>" 'toggle-frame-fullscreen)
 (bind-key "s-[" 'previous-buffer)
 (bind-key "s-]" 'next-buffer)


### PR DESCRIPTION
vertico-posframe made M-x appear dead: it hides minibuffer content via vscroll and renders candidates in a child frame, but child frames never become visible on this build (emacs-plus@31 pre-release 31.0.90 on macOS Tahoe), in or out of fullscreen. This PR removes the vertico-posframe block (added in #4) and the interim ns-use-native-fullscreen workaround, restoring normal vertico minibuffer display.

Kept from the init-completions.el review:
- Remove cape-ispell binding (command removed from cape upstream; C-c p i errored)
- Add :ensure t to consult-project-extra, consult-todo, cape
- Replace consult-todo :demand t with :commands to stop eager loading at startup
- Load embark-consult via embark-collect-mode hook with consult-preview-at-point-mode

The original minibuffer-shift annoyance can be revisited with vertico-buffer or a smaller vertico-count, or posframe again once the Emacs 31 build renders child frames on Tahoe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7gfjjamDPEWCejMYVCL5u